### PR TITLE
Update to latest Git version of `stm32l0xx-hal`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ embedded-hal = "0.2.3"
 nb = "0.1.2"
 
 [dependencies.stm32l0xx-hal]
-version  = "0.5.0"
+git      = "https://github.com/stm32-rs/stm32l0xx-hal.git"
 features = ["stm32l0x2", "rt"]
 
 
@@ -28,7 +28,7 @@ cortex-m-rtfm = "0.5.1"
 stm32-usbd  = "0.5.0"
 
 [dev-dependencies.stm32l0xx-hal]
-version  = "0.5.0"
+git      = "https://github.com/stm32-rs/stm32l0xx-hal.git"
 features = ["stm32-usbd"]
 
 [profile.release]

--- a/src/longfi_bindings.rs
+++ b/src/longfi_bindings.rs
@@ -18,21 +18,18 @@ type Uninitialized = Analog;
 pub type RadioIRQ = gpiob::PB0<Input<Floating>>;
 
 pub fn initialize_radio_irq(
-    pin: gpiob::PB0<Uninitialized>,
+    pin: gpiob::PB0<Input<Floating>>,
     syscfg: &mut hal::syscfg::SYSCFG,
     exti: &mut Exti,
 ) -> RadioIRQ {
-    // // Configure PB0 as input.
-    let dio1 = pin.into_floating_input();
-
     exti.listen_gpio(
         syscfg,
-        dio1.port(),
-        exti::GpioLine::from_raw_line(dio1.pin_number()).unwrap(),
+        pin.port(),
+        exti::GpioLine::from_raw_line(pin.pin_number()).unwrap(),
         exti::TriggerEdge::Rising,
     );
 
-    dio1
+    pin
 }
 
 impl LongFiBindings {

--- a/src/longfi_bindings.rs
+++ b/src/longfi_bindings.rs
@@ -1,5 +1,4 @@
 use crate::hal::prelude::*;
-use hal::device;
 use hal::exti;
 use hal::gpio::*;
 use hal::pac;
@@ -38,7 +37,7 @@ pub fn initialize_radio_irq(
 
 impl LongFiBindings {
     pub fn new(
-        spi_peripheral: device::SPI2,
+        spi_peripheral: pac::SPI2,
         rcc: &mut Rcc,
         rng: rng::Rng,
         spi_sck: gpiob::PB13<Uninitialized>,


### PR DESCRIPTION
I'm working on getting a downstream crate upgraded to the latest HAL version, to get access to [a fix](https://github.com/stm32-rs/stm32l0xx-hal/pull/78). For that, I need a branch to exist that upgrades this crates, so I figured I'd also submit it here. An alternative to merging this would be to wait until `stm32l0xx-hal` releases a new version (I can work off my branch in the meantime).